### PR TITLE
5 parse error types

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -10,6 +10,6 @@ readme.workspace = true
 version.workspace = true
 
 [dependencies]
-anyhow = "1"
 fnv = "1"
 paste = "1"
+thiserror = "1"

--- a/core/examples/simple.rs
+++ b/core/examples/simple.rs
@@ -6,6 +6,9 @@ use uri_template_system_core::{
 
 fn main() {
     let template = Template::parse("/literal/{simple}{/expanded*}").unwrap();
+
+    dbg!(&template);
+
     let values = Values::from_iter([
         ("simple".into(), Value::Item("hello".into())),
         (

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -36,5 +36,8 @@ pub use crate::{
             Values,
         },
     },
-    process::expand::Expansion,
+    process::{
+        expand::Expansion,
+        parse::ParseError,
+    },
 };

--- a/core/src/model/template.rs
+++ b/core/src/model/template.rs
@@ -17,7 +17,7 @@ use crate::{
         },
         parse::{
             ParseError,
-            ParseRef,
+            // ParseRef,
             TryParse,
         },
     },
@@ -32,7 +32,6 @@ use crate::{
 #[derive(Debug, Eq, PartialEq)]
 pub struct Template<'t> {
     components: Vec<Component<'t>>,
-    parse_ref: ParseRef<'t>,
 }
 
 impl<'t> Template<'t> {
@@ -45,11 +44,8 @@ impl<'t> Template<'t> {
         Self::try_parse(raw, 0).map(|(_, template)| template)
     }
 
-    const fn new(parse_ref: ParseRef<'t>, components: Vec<Component<'t>>) -> Self {
-        Self {
-            components,
-            parse_ref,
-        }
+    const fn new(components: Vec<Component<'t>>) -> Self {
+        Self { components }
     }
 }
 
@@ -59,12 +55,8 @@ impl<'t> Template<'t> {
 
 impl<'t> TryParse<'t> for Template<'t> {
     fn try_parse(raw: &'t str, global: usize) -> Result<(usize, Self), ParseError> {
-        Vec::<Component<'t>>::try_parse(raw, global).map(|(position, components)| {
-            (
-                position,
-                Self::new(ParseRef::new(0, position - 1, raw), components),
-            )
-        })
+        Vec::<Component<'t>>::try_parse(raw, global)
+            .map(|(position, components)| (position, Self::new(components)))
     }
 }
 

--- a/core/src/model/template.rs
+++ b/core/src/model/template.rs
@@ -5,8 +5,6 @@ use std::fmt::{
     Formatter,
 };
 
-use anyhow::Result;
-
 use crate::{
     model::{
         template::component::Component,
@@ -17,7 +15,11 @@ use crate::{
             Expand,
             Expansion,
         },
-        parse::TryParse,
+        parse::{
+            ParseError,
+            ParseRef,
+            TryParse,
+        },
     },
 };
 
@@ -29,8 +31,8 @@ use crate::{
 
 #[derive(Debug, Eq, PartialEq)]
 pub struct Template<'t> {
-    pub components: Vec<Component<'t>>,
-    pub raw: &'t str,
+    components: Vec<Component<'t>>,
+    parse_ref: ParseRef<'t>,
 }
 
 impl<'t> Template<'t> {
@@ -39,12 +41,15 @@ impl<'t> Template<'t> {
         Expansion::new(self, values)
     }
 
-    pub fn parse(raw: &'t str) -> Result<Self> {
-        Self::try_parse(raw).map(|(_, template)| template)
+    pub fn parse(raw: &'t str) -> Result<Self, ParseError> {
+        Self::try_parse(raw, 0).map(|(_, template)| template)
     }
 
-    const fn new(raw: &'t str, components: Vec<Component<'t>>) -> Self {
-        Self { components, raw }
+    const fn new(parse_ref: ParseRef<'t>, components: Vec<Component<'t>>) -> Self {
+        Self {
+            components,
+            parse_ref,
+        }
     }
 }
 
@@ -53,9 +58,13 @@ impl<'t> Template<'t> {
 // Parse
 
 impl<'t> TryParse<'t> for Template<'t> {
-    fn try_parse(raw: &'t str) -> Result<(usize, Self)> {
-        Vec::<Component<'t>>::try_parse(raw)
-            .map(|(_, components)| (raw.len(), Self::new(raw, components)))
+    fn try_parse(raw: &'t str, global: usize) -> Result<(usize, Self), ParseError> {
+        Vec::<Component<'t>>::try_parse(raw, global).map(|(position, components)| {
+            (
+                position,
+                Self::new(ParseRef::new(0, position - 1, raw), components),
+            )
+        })
     }
 }
 

--- a/core/src/model/template/component.rs
+++ b/core/src/model/template/component.rs
@@ -6,8 +6,6 @@ use std::fmt::{
     Formatter,
 };
 
-use anyhow::Result;
-
 use crate::{
     model::template::component::{
         expression::Expression,
@@ -15,7 +13,10 @@ use crate::{
     },
     process::{
         expand::Expand,
-        parse::TryParse,
+        parse::{
+            ParseError,
+            TryParse,
+        },
     },
     Values,
 };
@@ -37,7 +38,7 @@ pub enum Component<'t> {
 // Parse
 
 impl<'t> TryParse<'t> for Vec<Component<'t>> {
-    fn try_parse(raw: &'t str) -> Result<(usize, Self)> {
+    fn try_parse(raw: &'t str, global: usize) -> Result<(usize, Self), ParseError> {
         let mut parsed_components = Self::new(); // TODO: Check if a default capacity estimation improves perf
         let mut state = ComponentState::default();
 
@@ -49,10 +50,10 @@ impl<'t> TryParse<'t> for Vec<Component<'t>> {
             }
 
             let parsed = if rest.starts_with('{') {
-                Expression::try_parse(rest)
+                Expression::try_parse(rest, global + state.position)
                     .map(|(position, expression)| (position, Component::Expression(expression)))
             } else {
-                Literal::try_parse(rest)
+                Literal::try_parse(rest, global + state.position)
                     .map(|(position, literal)| (position, Component::Literal(literal)))
             };
 

--- a/core/src/model/template/component/expression.rs
+++ b/core/src/model/template/component/expression.rs
@@ -142,6 +142,7 @@ enum ExpressionNext {
 
 impl<'t> Expand for Expression<'t> {
     #[allow(clippy::cognitive_complexity)] // TODO: Reduce?
+    #[allow(clippy::equatable_if_let)]
     #[allow(clippy::too_many_lines)]
     fn expand(&self, values: &Values, f: &mut Formatter<'_>) -> fmt::Result {
         let behaviour = self

--- a/core/src/model/template/component/expression/operator.rs
+++ b/core/src/model/template/component/expression/operator.rs
@@ -3,7 +3,10 @@ use crate::{
         Allow,
         Behaviour,
     },
-    process::parse::Parse,
+    process::parse::{
+        Parse,
+        ParseRef,
+    },
 };
 
 // =============================================================================
@@ -17,16 +20,17 @@ pub enum Operator<'t> {
     Level2(OpLevel2<'t>),
     Level3(OpLevel3<'t>),
 }
+
 macro_rules! operator {
     ($name:ident) => {
         #[derive(Debug, Eq, PartialEq)]
         pub struct $name<'t> {
-            raw: &'t str,
+            parse_ref: ParseRef<'t>,
         }
 
         impl<'t> $name<'t> {
-            pub const fn new(raw: &'t str) -> Self {
-                Self { raw }
+            pub const fn new(parse_ref: ParseRef<'t>) -> Self {
+                Self { parse_ref }
             }
         }
     };
@@ -66,16 +70,16 @@ operator!(QueryContinuation);
 
 #[rustfmt::skip]
 impl<'t> Parse<'t> for Option<Operator<'t>> {
-    fn parse(raw: &'t str) -> (usize, Self) {
+    fn parse(raw: &'t str, global: usize) -> (usize, Self) {
         raw.chars().next().and_then(|c| {
             let operator = match c {
-                '+' => Some(Operator::Level2(OpLevel2::Reserved(Reserved::new(&raw[..1])))),
-                '#' => Some(Operator::Level2(OpLevel2::Fragment(Fragment::new(&raw[..1])))),
-                '.' => Some(Operator::Level3(OpLevel3::Label(Label::new(&raw[..1])))),
-                '/' => Some(Operator::Level3(OpLevel3::Path(Path::new(&raw[..1])))),
-                ';' => Some(Operator::Level3(OpLevel3::PathParameter(PathParameter::new(&raw[..1])))),
-                '?' => Some(Operator::Level3(OpLevel3::Query(Query::new(&raw[..1])))),
-                '&' => Some(Operator::Level3(OpLevel3::QueryContinuation(QueryContinuation::new(&raw[..1])))),
+                '+' => Some(Operator::Level2(OpLevel2::Reserved(Reserved::new(ParseRef::new(global, global, &raw[..1]))))),
+                '#' => Some(Operator::Level2(OpLevel2::Fragment(Fragment::new(ParseRef::new(global, global, &raw[..1]))))),
+                '.' => Some(Operator::Level3(OpLevel3::Label(Label::new(ParseRef::new(global, global, &raw[..1]))))),
+                '/' => Some(Operator::Level3(OpLevel3::Path(Path::new(ParseRef::new(global, global, &raw[..1]))))),
+                ';' => Some(Operator::Level3(OpLevel3::PathParameter(PathParameter::new(ParseRef::new(global, global, &raw[..1]))))),
+                '?' => Some(Operator::Level3(OpLevel3::Query(Query::new(ParseRef::new(global, global, &raw[..1]))))),
+                '&' => Some(Operator::Level3(OpLevel3::QueryContinuation(QueryContinuation::new(ParseRef::new(global, global, &raw[..1]))))),
                 _ => None,
             };
 

--- a/core/src/model/template/component/expression/variable.rs
+++ b/core/src/model/template/component/expression/variable.rs
@@ -2,7 +2,6 @@ use crate::{
     model::template::component::expression::modifier::Modifier,
     process::parse::{
         ParseError,
-        ParseRef,
         TryParse,
     },
     util::satisfy::{
@@ -22,21 +21,21 @@ use crate::{
 pub type VariableList<'t> = Vec<VariableSpecification<'t>>;
 
 #[allow(clippy::module_name_repetitions)]
-pub type VariableSpecification<'t> = (VariableName<'t>, Option<Modifier<'t>>);
+pub type VariableSpecification<'t> = (VariableName<'t>, Option<Modifier>);
 
 #[allow(clippy::module_name_repetitions)]
 #[derive(Debug, Eq, PartialEq)]
 pub struct VariableName<'t> {
-    parse_ref: ParseRef<'t>,
+    name: &'t str,
 }
 
 impl<'t> VariableName<'t> {
-    const fn new(parse_ref: ParseRef<'t>) -> Self {
-        Self { parse_ref }
+    const fn new(name: &'t str) -> Self {
+        Self { name }
     }
 
     pub const fn name(&self) -> &str {
-        self.parse_ref.raw
+        self.name
     }
 }
 
@@ -130,14 +129,7 @@ impl<'t> TryParse<'t> for VariableName<'t> {
                     state.next = VariableNameNext::VariableCharacters;
                 }
                 VariableNameNext::Dot => {
-                    return Ok((
-                        state.position,
-                        VariableName::new(ParseRef::new(
-                            global,
-                            global + state.position - 1,
-                            &raw[..state.position],
-                        )),
-                    ));
+                    return Ok((state.position, VariableName::new(&raw[..state.position])));
                 }
             }
         }

--- a/core/src/model/template/component/expression/variable.rs
+++ b/core/src/model/template/component/expression/variable.rs
@@ -1,11 +1,10 @@
-use anyhow::{
-    Error,
-    Result,
-};
-
 use crate::{
     model::template::component::expression::modifier::Modifier,
-    process::parse::TryParse,
+    process::parse::{
+        ParseError,
+        ParseRef,
+        TryParse,
+    },
     util::satisfy::{
         ascii::Ascii,
         percent_encoded::PercentEncoded,
@@ -28,16 +27,16 @@ pub type VariableSpecification<'t> = (VariableName<'t>, Option<Modifier<'t>>);
 #[allow(clippy::module_name_repetitions)]
 #[derive(Debug, Eq, PartialEq)]
 pub struct VariableName<'t> {
-    raw: &'t str,
+    parse_ref: ParseRef<'t>,
 }
 
 impl<'t> VariableName<'t> {
-    const fn new(raw: &'t str) -> Self {
-        Self { raw }
+    const fn new(parse_ref: ParseRef<'t>) -> Self {
+        Self { parse_ref }
     }
 
     pub const fn name(&self) -> &str {
-        self.raw
+        self.parse_ref.raw
     }
 }
 
@@ -48,7 +47,7 @@ impl<'t> VariableName<'t> {
 // Parse - Variable List
 
 impl<'t> TryParse<'t> for VariableList<'t> {
-    fn try_parse(raw: &'t str) -> Result<(usize, Self)> {
+    fn try_parse(raw: &'t str, global: usize) -> Result<(usize, Self), ParseError> {
         let mut parsed_variable_specifications = Self::new();
         let mut state = VariableListState::default();
 
@@ -63,15 +62,17 @@ impl<'t> TryParse<'t> for VariableList<'t> {
                 VariableListNext::Comma => {
                     return Ok((state.position, parsed_variable_specifications))
                 }
-                VariableListNext::VarSpec => match VariableSpecification::try_parse(rest) {
-                    Ok((position, variable_specification)) => {
-                        parsed_variable_specifications.push(variable_specification);
+                VariableListNext::VarSpec => {
+                    match VariableSpecification::try_parse(rest, global + state.position) {
+                        Ok((position, variable_specification)) => {
+                            parsed_variable_specifications.push(variable_specification);
 
-                        state.next = VariableListNext::Comma;
-                        state.position += position;
+                            state.next = VariableListNext::Comma;
+                            state.position += position;
+                        }
+                        Err(err) => return Err(err),
                     }
-                    Err(err) => return Err(err),
-                },
+                }
             }
         }
     }
@@ -93,9 +94,9 @@ enum VariableListNext {
 // Parse - Variable Specification
 
 impl<'t> TryParse<'t> for VariableSpecification<'t> {
-    fn try_parse(raw: &'t str) -> Result<(usize, Self)> {
-        VariableName::try_parse(raw).and_then(|(position_a, variable_name)| {
-            Option::<Modifier>::try_parse(&raw[position_a..])
+    fn try_parse(raw: &'t str, global: usize) -> Result<(usize, Self), ParseError> {
+        VariableName::try_parse(raw, global).and_then(|(position_a, variable_name)| {
+            Option::<Modifier>::try_parse(&raw[position_a..], global + position_a)
                 .map(|(position_b, modifier)| (position_a + position_b, (variable_name, modifier)))
         })
     }
@@ -104,28 +105,40 @@ impl<'t> TryParse<'t> for VariableSpecification<'t> {
 // Parse - Variable Name
 
 impl<'t> TryParse<'t> for VariableName<'t> {
-    // TODO: Experiment with ordering for perf?
-    fn try_parse(raw: &'t str) -> Result<(usize, Self)> {
+    fn try_parse(raw: &'t str, global: usize) -> Result<(usize, Self), ParseError> {
         let mut state = VariableNameState::default();
 
         loop {
             let rest = &raw[state.position..];
 
             match &state.next {
-                VariableNameNext::Dot if rest.starts_with('.') => {
-                    state.position += 1;
-                    state.next = VariableNameNext::VariableCharacters;
-                }
-                VariableNameNext::Dot => {
-                    return Ok((state.position, VariableName::new(&raw[..state.position])));
-                }
                 VariableNameNext::VariableCharacters => match satisfier().satisfy(rest) {
-                    0 => return Err(Error::msg("varname: expected valid char(s)")),
+                    0 => {
+                        return Err(ParseError::UnexpectedInput {
+                            position: global + state.position,
+                            message: "unexpected input parsing variable name".into(),
+                            expected: "valid var_name characters (see: https://datatracker.ietf.org/doc/html/rfc6570#section-2.3)".into(),
+                        })
+                    }
                     n => {
                         state.position += n;
                         state.next = VariableNameNext::Dot;
                     }
                 },
+                VariableNameNext::Dot if rest.starts_with('.') => {
+                    state.position += 1;
+                    state.next = VariableNameNext::VariableCharacters;
+                }
+                VariableNameNext::Dot => {
+                    return Ok((
+                        state.position,
+                        VariableName::new(ParseRef::new(
+                            global,
+                            global + state.position - 1,
+                            &raw[..state.position],
+                        )),
+                    ));
+                }
             }
         }
     }

--- a/core/src/model/template/component/literal.rs
+++ b/core/src/model/template/component/literal.rs
@@ -9,7 +9,6 @@ use crate::{
         expand::Expand,
         parse::{
             ParseError,
-            ParseRef,
             TryParse,
         },
     },
@@ -33,12 +32,12 @@ use crate::{
 
 #[derive(Debug, Eq, PartialEq)]
 pub struct Literal<'t> {
-    parse_ref: ParseRef<'t>,
+    value: &'t str,
 }
 
 impl<'t> Literal<'t> {
-    pub const fn new(parse_ref: ParseRef<'t>) -> Self {
-        Self { parse_ref }
+    pub const fn new(value: &'t str) -> Self {
+        Self { value }
     }
 }
 
@@ -54,7 +53,7 @@ impl<'t> TryParse<'t> for Literal<'t> {
                 message: "unexpected input parsing literal component".into(),
                 expected: "valid literal characters (see: https://datatracker.ietf.org/doc/html/rfc6570#section-2.1)".into(),
             }),
-            n => Ok((n, Literal::new(ParseRef::new(global, global + n - 1, &raw[..n])))),
+            n => Ok((n, Literal::new(&raw[..n]))),
         }
     }
 }
@@ -120,6 +119,6 @@ const fn is_literal_unicode(c: char) -> bool {
 
 impl<'t> Expand for Literal<'t> {
     fn expand(&self, _values: &Values, f: &mut Formatter<'_>) -> fmt::Result {
-        f.encode(self.parse_ref.raw, &satisfy::unreserved_or_reserved())
+        f.encode(self.value, &satisfy::unreserved_or_reserved())
     }
 }

--- a/core/src/process/parse.rs
+++ b/core/src/process/parse.rs
@@ -25,6 +25,7 @@ where
 
 // Errors
 
+#[allow(clippy::module_name_repetitions)]
 #[derive(Debug, Error)]
 pub enum ParseError {
     #[error("{message} at position: {position}. expected: {expected}.")]

--- a/core/src/process/parse.rs
+++ b/core/src/process/parse.rs
@@ -21,19 +21,6 @@ where
     fn try_parse(raw: &'t str, base: usize) -> Result<(usize, Self), ParseError>;
 }
 
-#[derive(Debug, Eq, PartialEq)]
-pub struct ParseRef<'t> {
-    pub start: usize,
-    pub end: usize,
-    pub raw: &'t str,
-}
-
-impl<'t> ParseRef<'t> {
-    pub const fn new(start: usize, end: usize, raw: &'t str) -> Self {
-        Self { start, end, raw }
-    }
-}
-
 // -----------------------------------------------------------------------------
 
 // Errors

--- a/core/src/process/parse.rs
+++ b/core/src/process/parse.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use thiserror::Error;
 
 // =============================================================================
 // Parse
@@ -10,7 +10,7 @@ pub trait Parse<'t>
 where
     Self: Sized,
 {
-    fn parse(raw: &'t str) -> (usize, Self);
+    fn parse(raw: &'t str, global: usize) -> (usize, Self);
 }
 
 #[allow(clippy::module_name_repetitions)]
@@ -18,5 +18,32 @@ pub trait TryParse<'t>
 where
     Self: Sized,
 {
-    fn try_parse(raw: &'t str) -> Result<(usize, Self)>;
+    fn try_parse(raw: &'t str, base: usize) -> Result<(usize, Self), ParseError>;
+}
+
+#[derive(Debug, Eq, PartialEq)]
+pub struct ParseRef<'t> {
+    pub start: usize,
+    pub end: usize,
+    pub raw: &'t str,
+}
+
+impl<'t> ParseRef<'t> {
+    pub const fn new(start: usize, end: usize, raw: &'t str) -> Self {
+        Self { start, end, raw }
+    }
+}
+
+// -----------------------------------------------------------------------------
+
+// Errors
+
+#[derive(Debug, Error)]
+pub enum ParseError {
+    #[error("{message} at position: {position}. expected: {expected}.")]
+    UnexpectedInput {
+        position: usize,
+        message: String,
+        expected: String,
+    },
 }


### PR DESCRIPTION
resolves #5, and also removes references to the input from components where it isn't needed (only now present in literals and variable names)